### PR TITLE
Update dependencies for PHP 8.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,12 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "spatie/laravel-package-tools": "^1.14",
-        "illuminate/contracts": "^10.0"
+        "php": "^8.2",
+        "spatie/laravel-package-tools": "^1.16",
+        "illuminate/contracts": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/database": "^10.0",
+        "illuminate/notifications": "^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
## Summary
- require PHP 8.2 or newer

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/pest` *(fails: No such file or directory)*