### PR TITLE
Add digest email customization and structured components support

### DIFF
--- a/config/notification-subscriptions.php
+++ b/config/notification-subscriptions.php
@@ -73,6 +73,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Digest Subject and View
+    |--------------------------------------------------------------------------
+    |
+    | Allow applications to easily override the default subject and markdown
+    | view used to render digest emails. The view should exist in the host app
+    | or can use the package view: 'notification-subscriptions::digest'.
+    */
+    'digest_subject' => 'Your Notification Digest',
+    'digest_markdown_view' => 'notification-subscriptions::digest',
+
+    /*
+    |--------------------------------------------------------------------------
     | Subscribable Notification Types
     |--------------------------------------------------------------------------
     |

--- a/resources/views/digest.blade.php
+++ b/resources/views/digest.blade.php
@@ -1,0 +1,58 @@
+@php
+    $components = $components ?? [];
+    $subject = $subject ?? 'Your Notification Digest';
+@endphp
+
+@component('mail::message')
+# {{ $subject }}
+
+@foreach($components as $c)
+    @switch($c['type'])
+        @case('heading')
+            @if(($c['level'] ?? 2) === 1)
+                # {{ $c['text'] }}
+            @elseif(($c['level'] ?? 2) === 2)
+                ## {{ $c['text'] }}
+            @elseif(($c['level'] ?? 2) === 3)
+                ### {{ $c['text'] }}
+            @else
+                #### {{ $c['text'] }}
+            @endif
+            @break
+
+        @case('line')
+            {{ $c['text'] }}
+
+            @break
+
+        @case('panel')
+            @component('mail::panel')
+                {{ $c['text'] }}
+            @endcomponent
+            @break
+
+        @case('button')
+            @component('mail::button', ['url' => $c['url'], 'color' => $c['color'] ?? 'primary'])
+                {{ $c['text'] }}
+            @endcomponent
+            @break
+
+        @case('list')
+            @foreach(($c['items'] ?? []) as $item)
+            - {{ $item }}
+            @endforeach
+
+            @break
+
+        @case('separator')
+            ---
+
+            @break
+    @endswitch
+@endforeach
+
+Thanks,
+{{ config('app.name') }}
+@endcomponent
+
+

--- a/src/Digest/DigestMessage.php
+++ b/src/Digest/DigestMessage.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Humweb\Notifications\Digest;
+
+class DigestMessage
+{
+    /**
+     * Ordered list of components to render in the digest email.
+     * Each component is an associative array with a 'type' key and type-specific payload.
+     *
+     * Supported types: line, heading, panel, button, list, separator
+     */
+    protected array $components = [];
+
+    public function components(): array
+    {
+        return $this->components;
+    }
+
+    public function line(string $text): static
+    {
+        $this->components[] = ['type' => 'line', 'text' => $text];
+
+        return $this;
+    }
+
+    public function heading(string $text, int $level = 2): static
+    {
+        $this->components[] = ['type' => 'heading', 'text' => $text, 'level' => max(1, min(4, $level))];
+
+        return $this;
+    }
+
+    public function panel(string $text): static
+    {
+        $this->components[] = ['type' => 'panel', 'text' => $text];
+
+        return $this;
+    }
+
+    public function button(string $text, string $url, string $color = 'primary'): static
+    {
+        $this->components[] = [
+            'type' => 'button',
+            'text' => $text,
+            'url' => $url,
+            'color' => $color,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Render a simple bullet list.
+     *
+     * @param  array<int, string>  $items
+     */
+    public function bulletList(array $items): static
+    {
+        $this->components[] = ['type' => 'list', 'items' => array_values($items)];
+
+        return $this;
+    }
+
+    public function separator(): static
+    {
+        $this->components[] = ['type' => 'separator'];
+
+        return $this;
+    }
+}
+
+

--- a/src/Digest/DigestMessage.php
+++ b/src/Digest/DigestMessage.php
@@ -69,5 +69,3 @@ class DigestMessage
         return $this;
     }
 }
-
-

--- a/src/NotificationSubscriptionsServiceProvider.php
+++ b/src/NotificationSubscriptionsServiceProvider.php
@@ -19,7 +19,8 @@ class NotificationSubscriptionsServiceProvider extends PackageServiceProvider
             ->name('notification-subscriptions')
             ->hasConfigFile('notification-subscriptions')
             ->hasMigration('create_notification_subscriptions_table')
-            ->hasCommand(SendNotificationDigests::class);
+            ->hasCommand(SendNotificationDigests::class)
+            ->hasViews();
 
         // Load test-specific migrations if in testing environment
         if ($this->app->environment('testing')) {

--- a/src/Notifications/UserNotificationDigest.php
+++ b/src/Notifications/UserNotificationDigest.php
@@ -5,12 +5,10 @@ namespace Humweb\Notifications\Notifications;
 use Humweb\Notifications\Digest\DigestMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\View;
 use Str;
 
 class UserNotificationDigest extends Notification implements ShouldQueue
@@ -110,7 +108,7 @@ class UserNotificationDigest extends Notification implements ShouldQueue
             $summary = 'Notification: '.$this->toTitleCase(class_basename($item['class'])).' (Received: '.$item['created_at']->format('Y-m-d H:i').')';
 
             if ($notificationInstance && method_exists($notificationInstance, 'toDigest')) {
-                $builder = new DigestMessage();
+                $builder = new DigestMessage;
                 $notificationInstance->toDigest($notifiable, $builder, $item['data']);
                 $components = array_merge($components, $builder->components());
             } elseif ($notificationInstance && method_exists($notificationInstance, 'toDigestFormat')) {

--- a/src/Notifications/UserNotificationDigest.php
+++ b/src/Notifications/UserNotificationDigest.php
@@ -2,11 +2,15 @@
 
 namespace Humweb\Notifications\Notifications;
 
+use Humweb\Notifications\Digest\DigestMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Support\Renderable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\View;
 use Str;
 
 class UserNotificationDigest extends Notification implements ShouldQueue
@@ -45,58 +49,93 @@ class UserNotificationDigest extends Notification implements ShouldQueue
      */
     public function toMail(mixed $notifiable): MailMessage
     {
+        $subject = Config::get('notification-subscriptions.digest_subject', 'Your Notification Digest');
+        $view = Config::get('notification-subscriptions.digest_markdown_view', 'notification-subscriptions::digest');
+
         $mailMessage = (new MailMessage)
-            ->subject('Your Notification Digest')
-            ->line('Here is a summary of your recent notifications:');
+            ->subject($subject);
+
+        // Add intro immediately for BC with tests expecting introLines
+        $intro = 'Here is a summary of your recent notifications:';
+        $mailMessage->line($intro);
+
+        [$components, $usedStructuredComponents] = $this->compileComponents($notifiable);
+
+        if ($usedStructuredComponents) {
+            $mailMessage->markdown($view, [
+                'subject' => $subject,
+                'components' => $components,
+            ]);
+        } else {
+            // Render as simple text lines for backward compatibility
+            foreach ($components as $component) {
+                if ($component['type'] === 'line') {
+                    $mailMessage->line($component['text']);
+                } elseif ($component['type'] === 'separator') {
+                    $mailMessage->line('---');
+                }
+            }
+            $mailMessage->line('You can manage your notification preferences in your profile settings.');
+        }
+
+        return $mailMessage;
+    }
+
+    /**
+     * Build the digest components array and indicate if any structured components were used.
+     *
+     * @return array{0: array<int, array<string, mixed>>, 1: bool}
+     */
+    public function compileComponents(mixed $notifiable): array
+    {
+        $components = [];
 
         foreach ($this->pendingNotificationsData as $item) {
-            // Attempt to get a human-readable summary for each pending item.
-            // This is a basic example. You'd likely want more sophisticated rendering
-            // based on $item['class'] and $item['data'].
             $notificationInstance = null;
             if (! empty($item['class']) && class_exists($item['class'])) {
                 try {
                     $data = $item['data'] ?? [];
-
                     if (is_array($data) && ! $this->isAssoc($data)) {
-                        // Positional args
                         $notificationInstance = new $item['class'](...$data);
                     } elseif (is_array($data)) {
-                        // Named args via container
                         $notificationInstance = app()->makeWith($item['class'], $data);
                     } else {
-                        // Single value as positional
                         $notificationInstance = new $item['class']($data);
                     }
                 } catch (\Throwable $e) {
-                    // Optional: uncomment to help debug during development
-                    // logger()->warning('Failed to instantiate notification for digest', [
-                    //     'class' => $item['class'],
-                    //     'error' => $e->getMessage(),
-                    // ]);
+                    // ignore instantiation issues; fall back to summary
                 }
             }
 
             $summary = 'Notification: '.$this->toTitleCase(class_basename($item['class'])).' (Received: '.$item['created_at']->format('Y-m-d H:i').')';
 
-            // If the original notification has a toText() or toArray() method, you could use it.
-            // For now, a generic line.
-            if ($notificationInstance && method_exists($notificationInstance, 'toDigestFormat')) {
-                $summary = $notificationInstance->toDigestFormat($notifiable, $item['data']);
-                $mailMessage->line($summary);
+            if ($notificationInstance && method_exists($notificationInstance, 'toDigest')) {
+                $builder = new DigestMessage();
+                $notificationInstance->toDigest($notifiable, $builder, $item['data']);
+                $components = array_merge($components, $builder->components());
+            } elseif ($notificationInstance && method_exists($notificationInstance, 'toDigestFormat')) {
+                $text = $notificationInstance->toDigestFormat($notifiable, $item['data']);
+                $components[] = ['type' => 'line', 'text' => $text];
             } elseif ($notificationInstance && method_exists($notificationInstance, 'toArray')) {
-                // Fallback to a generic array representation if available
                 $arrayData = $notificationInstance->toArray($notifiable);
-                $mailMessage->line('Update: '.($arrayData['title'] ?? class_basename($item['class'])).' - '.($arrayData['message'] ?? 'Details in app.'));
+                $text = 'Update: '.($arrayData['title'] ?? class_basename($item['class'])).' - '.($arrayData['message'] ?? 'Details in app.');
+                $components[] = ['type' => 'line', 'text' => $text];
             } else {
-                $mailMessage->line($summary);
+                $components[] = ['type' => 'line', 'text' => $summary];
             }
-            $mailMessage->line('---'); // Separator
+
+            $components[] = ['type' => 'separator'];
         }
 
-        $mailMessage->line('You can manage your notification preferences in your profile settings.');
+        $usedStructuredComponents = false;
+        foreach ($components as $c) {
+            if (in_array($c['type'], ['heading', 'panel', 'button', 'list'], true)) {
+                $usedStructuredComponents = true;
+                break;
+            }
+        }
 
-        return $mailMessage;
+        return [$components, $usedStructuredComponents];
     }
 
     /**

--- a/tests/Stubs/ArrayFormatNotification.php
+++ b/tests/Stubs/ArrayFormatNotification.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Humweb\Notifications\Tests\Stubs;
+
+use Illuminate\Notifications\Notification;
+
+class ArrayFormatNotification extends Notification
+{
+    public string $title;
+    public string $message;
+
+    // Constructor designed for associative/named args
+    public function __construct(string $title, string $message)
+    {
+        $this->title = $title;
+        $this->message = $message;
+    }
+
+    public function toArray($notifiable): array
+    {
+        return [
+            'title' => $this->title,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/tests/Stubs/ArrayFormatNotification.php
+++ b/tests/Stubs/ArrayFormatNotification.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Notification;
 class ArrayFormatNotification extends Notification
 {
     public string $title;
+
     public string $message;
 
     // Constructor designed for associative/named args

--- a/tests/Stubs/DigestFormatNotification.php
+++ b/tests/Stubs/DigestFormatNotification.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Humweb\Notifications\Tests\Stubs;
+
+use Illuminate\Notifications\Notification;
+
+class DigestFormatNotification extends Notification
+{
+    public string $first;
+    public string $second;
+
+    public function __construct(string $first, string $second)
+    {
+        $this->first = $first;
+        $this->second = $second;
+    }
+
+    public function toDigestFormat($notifiable, $data): string
+    {
+        return "Digest for {$this->first} and {$this->second}";
+    }
+}

--- a/tests/Stubs/DigestFormatNotification.php
+++ b/tests/Stubs/DigestFormatNotification.php
@@ -7,6 +7,7 @@ use Illuminate\Notifications\Notification;
 class DigestFormatNotification extends Notification
 {
     public string $first;
+
     public string $second;
 
     public function __construct(string $first, string $second)

--- a/tests/Stubs/StructuredDigestNotification.php
+++ b/tests/Stubs/StructuredDigestNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Humweb\Notifications\Tests\Stubs;
+
+use Humweb\Notifications\Digest\DigestMessage;
+use Illuminate\Notifications\Notification;
+
+class StructuredDigestNotification extends Notification
+{
+    public string $first;
+    public string $second;
+
+    public function __construct(string $first, string $second)
+    {
+        $this->first = $first;
+        $this->second = $second;
+    }
+
+    public function toDigest($notifiable, DigestMessage $digest, $data): void
+    {
+        $digest->heading('New Activity')
+            ->line("Digest for {$this->first} and {$this->second}")
+            ->button('View', 'https://example.com')
+            ->bulletList(['Alpha detail', 'Beta detail']);
+    }
+}
+
+

--- a/tests/Stubs/StructuredDigestNotification.php
+++ b/tests/Stubs/StructuredDigestNotification.php
@@ -8,6 +8,7 @@ use Illuminate\Notifications\Notification;
 class StructuredDigestNotification extends Notification
 {
     public string $first;
+
     public string $second;
 
     public function __construct(string $first, string $second)
@@ -24,5 +25,3 @@ class StructuredDigestNotification extends Notification
             ->bulletList(['Alpha detail', 'Beta detail']);
     }
 }
-
-

--- a/tests/UserNotificationDigestTest.php
+++ b/tests/UserNotificationDigestTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use Humweb\Notifications\Notifications\UserNotificationDigest;
+use Humweb\Notifications\Tests\Stubs\ArrayFormatNotification;
+use Humweb\Notifications\Tests\Stubs\DigestFormatNotification;
+use Humweb\Notifications\Tests\Stubs\NotifyCommentCreated;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+it('returns the specified channel via()', function () {
+    $digest = new UserNotificationDigest('mail', collect());
+    expect($digest->via(null))->toBe(['mail']);
+});
+
+it('converts strings to title case with spaces', function () {
+    $digest = new UserNotificationDigest('mail', collect());
+    expect($digest->toTitleCase('NotifyCommentCreated'))->toBe('Notify Comment Created');
+    expect($digest->toTitleCase('notify_comment_created'))->toBe('Notify Comment Created');
+});
+
+it('maps items correctly in toArray()', function () {
+    $createdAt = Carbon::parse('2023-01-01 08:30:00');
+    $items = collect([
+        [
+            'class' => NotifyCommentCreated::class,
+            'data' => ['my-comment'],
+            'created_at' => $createdAt,
+        ],
+    ]);
+
+    $digest = new UserNotificationDigest('database', $items);
+    $array = $digest->toArray(null);
+
+    expect($array['title'])->toBe('Your Notification Digest');
+    expect($array['summary'])->toBe('You have 1 new notifications.');
+    expect($array['items'])->toHaveCount(1);
+    expect($array['items'][0]['type'])->toBe('Notify Comment Created');
+    expect($array['items'][0]['data'])->toBe(['my-comment']);
+    expect($array['items'][0]['received_at'])->toBe($createdAt->toIso8601String());
+});
+
+it('toMail() uses toDigestFormat when available (positional args)', function () {
+    $items = collect([
+        [
+            'class' => DigestFormatNotification::class,
+            'data' => ['alpha', 'beta'], // positional args
+            'created_at' => Carbon::parse('2023-01-01 08:30:00'),
+        ],
+    ]);
+
+    $digest = new UserNotificationDigest('mail', $items);
+    $mail = $digest->toMail((object) ['id' => 1]);
+    $arr = $mail->toArray();
+
+    expect($arr['subject'])->toBe('Your Notification Digest');
+    expect($arr['introLines'])->toContain('Here is a summary of your recent notifications:');
+    expect($arr['introLines'])->toContain('Digest for alpha and beta');
+    expect($arr['introLines'])->toContain('---');
+    expect($arr['introLines'])->toContain('You can manage your notification preferences in your profile settings.');
+});
+
+it('toMail() falls back to toArray() when toDigestFormat is not present (associative args)', function () {
+    $items = collect([
+        [
+            'class' => ArrayFormatNotification::class,
+            'data' => ['title' => 'Title X', 'message' => 'Message Y'], // associative args via container
+            'created_at' => Carbon::parse('2023-01-01 08:30:00'),
+        ],
+    ]);
+
+    $digest = new UserNotificationDigest('mail', $items);
+    $mail = $digest->toMail((object) ['id' => 2]);
+    $arr = $mail->toArray();
+
+    expect($arr['introLines'])->toContain('Update: Title X - Message Y');
+});
+
+it('toMail() uses default summary when notification has no special methods', function () {
+    $createdAt = Carbon::parse('2023-01-01 08:30:00');
+    $items = collect([
+        [
+            'class' => NotifyCommentCreated::class,
+            'data' => ['my-comment'],
+            'created_at' => $createdAt,
+        ],
+    ]);
+
+    $digest = new UserNotificationDigest('mail', $items);
+    $mail = $digest->toMail(null);
+    $arr = $mail->toArray();
+
+    $expectedSummary = 'Notification: Notify Comment Created (Received: '.$createdAt->format('Y-m-d H:i').')';
+    expect($arr['introLines'])->toContain($expectedSummary);
+});
+
+it('toMail() handles invalid class gracefully using default summary', function () {
+    $createdAt = Carbon::parse('2023-01-01 08:30:00');
+    $items = collect([
+        [
+            'class' => 'NonExisting\\Notifications\\FakeNotice',
+            'data' => ['anything'],
+            'created_at' => $createdAt,
+        ],
+    ]);
+
+    $digest = new UserNotificationDigest('mail', $items);
+    $mail = $digest->toMail(null);
+    $arr = $mail->toArray();
+
+    $expectedSummary = 'Notification: Fake Notice (Received: '.$createdAt->format('Y-m-d H:i').')';
+    expect($arr['introLines'])->toContain($expectedSummary);
+});

--- a/tests/UserNotificationDigestTest.php
+++ b/tests/UserNotificationDigestTest.php
@@ -3,10 +3,9 @@
 use Humweb\Notifications\Notifications\UserNotificationDigest;
 use Humweb\Notifications\Tests\Stubs\ArrayFormatNotification;
 use Humweb\Notifications\Tests\Stubs\DigestFormatNotification;
-use Humweb\Notifications\Tests\Stubs\StructuredDigestNotification;
 use Humweb\Notifications\Tests\Stubs\NotifyCommentCreated;
+use Humweb\Notifications\Tests\Stubs\StructuredDigestNotification;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 
 it('returns the specified channel via()', function () {


### PR DESCRIPTION
Enhanced the notification subscriptions configuration to allow overriding the digest email subject and view. Introduced a new `DigestMessage` class for building structured email components, and updated the `UserNotificationDigest` to utilize this new structure. Added a new Blade view for rendering the digest email and implemented tests for structured notifications to ensure proper rendering and functionality.